### PR TITLE
changed error message

### DIFF
--- a/listeners/message.js
+++ b/listeners/message.js
@@ -22,8 +22,8 @@ class MessageListener extends Listener {
         message.channel.send(
           new MessageEmbed(embed)
             .setTimestamp(new Date())
-            .setTitle("We don't support file debugging!")
-            .setDescription('Please paste your code on a [website](https://gist.github.com) or in a [code block](https://discordapp.com/channels/420594746990526466/549794917036326912/555379356604825610).')
+            .setTitle("Sorry, your code was too long for discord. Please use website link below to paste your code.")
+            .setDescription('Please paste your code on a [website](https://pastebin.com) or in a [code block](https://discordapp.com/channels/420594746990526466/549794917036326912/555379356604825610).')
             .setAuthor(message.author.tag, message.author.avatarURL({ dynamic: true }))
         )
       }).catch(err => {


### PR DESCRIPTION
the problem is that people doesnt uploads text files for debug. the problem is that too long code blocks are automaticaly converted to text attachments. so previous messages is really confusing. why bot talks about files then code block was created? 
also, i dont think that every kid or student has github to create gist so website like pastebin would be more useful because doenst requeres registration.

p.s. if you know how to improve this error message to be more user friendly - i can update PR 