### PR TITLE
 added txt, ino, cpp, h, py, and js file extensions to whitelist, and made changes to codeblock tag accordingly.

### DIFF
--- a/listeners/message.js
+++ b/listeners/message.js
@@ -14,7 +14,7 @@ class MessageListener extends Listener {
   exec(message) {
     // File filter
     if (message.attachments.find(attachment => {
-      const allowedExtensions = ['png', 'jpg', 'gif', 'webp', 'tiff', 'heif', 'jpeg', 'svg', 'webm', 'mpg', 'mpeg', 'ogg', 'mp4', 'm4v', 'avi', 'mov', 'm4a', 'mp3', 'wav', 'pdf']
+      const allowedExtensions = ['png', 'jpg', 'gif', 'webp', 'tiff', 'heif', 'jpeg', 'svg', 'webm', 'mpg', 'mpeg', 'ogg', 'mp4', 'm4v', 'avi', 'mov', 'm4a', 'mp3', 'wav', 'pdf', 'txt', 'ino', 'cpp', 'h', 'py', 'js']
       const extension = attachment.name.split('.').pop().toLowerCase()
       return (!allowedExtensions.includes(extension)) && (!message.member.roles.cache.find(role => role.id === '451152561735467018'))
     })) {
@@ -22,8 +22,8 @@ class MessageListener extends Listener {
         message.channel.send(
           new MessageEmbed(embed)
             .setTimestamp(new Date())
-            .setTitle("We don't support file debugging!")
-            .setDescription('Please paste your code on a [website](https://gist.github.com) or in a [code block](https://discordapp.com/channels/420594746990526466/549794917036326912/555379356604825610).')
+            .setTitle("We don't support this file extension!")
+            .setDescription('if someone is trying to assist you, and you really need to post this file, **ask for permission to Direct Message them**.')
             .setAuthor(message.author.tag, message.author.avatarURL({ dynamic: true }))
         )
       }).catch(err => {

--- a/tags/codeblock.json
+++ b/tags/codeblock.json
@@ -1,12 +1,11 @@
 {
-  "title": "How to Send Code Blocks",
+  "title": "How to Send Code:-",
   "aliases": ["codeblock", "code", "codeblocks", "block"],
   "directAliases": ["codeblock", "code"],
   "fields": [
     {
-      "name": "Surround the code in three backticks",
-      "value": "If using new lines, a file extension can be placed directly after the first 3 backticks to highlight in that language. An example is shown below, highlighting code in arduino. The backtick key is typically found to the left of the 1 key."
+      "name": "Post the file containing your code directly.",
+      "value": "click on the upload button (the big + button) to the left of your message bar, then, select and upload your files **carefully** so you can seek help with your code."
     }
-  ],
-  "image": "https://this-u.lol/09kbow.png"
+  ]
 }


### PR DESCRIPTION
in the recent discord remake, discord now previews these files, hence gist and codeblocks are no longer needed, and files can be uploaded directly. although I have made changes to the codeblock tag and the "file debugging is not supported" message, they aren't perfect, so I would like your feedback. sorry @BluLightShow for the constant PR's! :wink:
